### PR TITLE
Fix link to Unity-Theme-Database.json in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Close Unity project to avoid any data loss.
 
 ### Step 3 - database template
 
-- Download [Unity-Theme-Database.json](https://raw.githubusercontent.com/IvanMurzak/Unity-Theme/refs/heads/main/Assets/Resources/Unity-Theme-Database.json).
+- Download [Unity-Theme-Database.json](https://raw.githubusercontent.com/IvanMurzak/Unity-Theme/refs/heads/main/Unity-Theme/Assets/Resources/Unity-Theme-Database.json).
 - Save it at `Assets/Resources/Unity-Theme-Database.json`.
 - Use it as a template. Feel free to delete all existed colors if you want.
 


### PR DESCRIPTION
This pull request updates the download link for the Unity theme database file in the `README.md` to reflect its new location. This ensures users are directed to the correct file path when setting up the project.

Documentation update:

* Updated the download URL for `Unity-Theme-Database.json` in the setup instructions to point to its new location under `Unity-Theme/Assets/Resources/Unity-Theme-Database.json`.